### PR TITLE
2 commits

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -419,10 +419,10 @@ end
 ---
 
 -- Load default ranks
-dofile(minetest.get_modpath("ranks").."/ranks.lua")
-
 local path = minetest.get_worldpath().."/ranks.lua"
 -- Attempt to load per-world ranks
 if io.open(path) then
 	dofile(path)
+else
+	dofile(minetest.get_modpath("ranks").."/ranks.lua")
 end

--- a/init.lua
+++ b/init.lua
@@ -250,6 +250,12 @@ minetest.register_privilege("rank", {
 	give_to_singleplayer = false,
 })
 
+-- [privilege] Rank Sudo
+minetest.register_privilege("rank_sudo", {
+	description = "Permission to use /sudo chatcommand",
+	give_to_singleplayer = false,
+})
+
 -- Assign/update rank on join player
 minetest.register_on_joinplayer(function(player)
 	if ranks.get_rank(player) then
@@ -268,6 +274,48 @@ end)
 minetest.register_on_chat_message(function(name, message)
 	return ranks.chat_send(name, message)
 end)
+
+-- [chatcommand] /sudo
+minetest.register_chatcommand("sudo", {
+	params = "<your name>",
+	description = "Start or update your sudo status",
+	privs = {rank_sudo=true},
+	func = function(name, param)
+			
+		if (param == nil or param == "") then
+			return true, "Its annoying but it is suppose to be, Call sudo like so: /sudo <your_username>"
+		end
+		
+		if (param ~= name and param ~= "-") then
+			return true, param.." is not your name, Call sudo like so: /sudo <your_username>"
+		end
+		
+		if (param == "-") then
+			ranks.update_privs(name)
+			return true, "You no longer have sudo privs"
+		end
+		
+		local player_rank	= ranks.get_rank(name)
+		if (player_rank == nil) then
+			return true, "Player does not have a rank"
+		end
+		
+		local new_privs	= {}
+		
+		for k,v in pairs(ranks.get_def(player_rank).privs) do 
+			new_privs[k] = v
+		end
+		
+		for k,v in pairs(ranks.get_def(player_rank).sudo_privs) do 
+			new_privs[k] = v
+		end
+		
+		minetest.set_player_privs(name, new_privs)
+
+		return true, "[Profiles] You have sudo privs, to come out of sudo you can logout and back in or use: /sudo -"
+		
+	end,
+})
 
 -- [chatcommand] /rank
 minetest.register_chatcommand("rank", {


### PR DESCRIPTION
**commit 1:** 
Adds the ability for admins to play as a regular player but then by using the "sudo <player_name>" command can enable an additional set of privs.

For example server owners can make it so that admins can only fly and noclip only after using sudo command

Sudo privs remove from a player when the player logs off or uses "/sudo -"

You must add rank_sudo to the ranks you want to be able to use the sudo command

Then define the privs that are given with the sudo command by adding the following to the rank definition.

`sudo_privs = {fly = true....}`


------------------------------------
**Commit 2:** 
Only load the default ranks.lua file if the world directory does not already contain one. it makes no sense to load 2 ranks.lua files.