### PR TITLE
Add world storage for player ranks

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -183,7 +183,7 @@ function ranks.set_rank(name, rank)
 		name = name:get_player_name()
 	end
 
-	if registered[rank] then
+	if registered[rank] and minetest.player_exists(name) then
 		storage:set_string(name, rank)
 
 		-- Update nametag
@@ -208,12 +208,6 @@ function ranks.remove_rank(name)
 		storage:set_string(name, nil)
 
 		if player then
-
-			-- Remove old rank storage if exists
-			if player:get_attribute("ranks:rank") ~= "" then
-				player:set_attribute("ranks:rank", nil)
-			end
-
 			-- Update nametag
 			player:set_nametag_attributes({
 				text = name,
@@ -263,8 +257,19 @@ minetest.register_on_joinplayer(function(player)
 	local name = player:get_player_name()
 
 	-- If database item exists and new storage item does not, use database item
-	if player:get_attribute("ranks:rank") ~= "" and storage:get_string(name, rank) == "" then
+	if player:get_attribute("ranks:rank") ~= nil and storage:get_string(name, rank) == "" then
+		-- Add entry into new storage system
 		storage:set_string(name, player:get_attribute("ranks:rank"))
+
+		-- Store backup then invalidate database item
+		player:set_attribute("ranks:rank-old", player:get_attribute("ranks:rank"))
+		player:set_attribute("ranks:rank", nil)
+	end
+
+	-- Both items exist, remove old one
+	if player:get_attribute("ranks:rank") ~= nil and storage:get_string(name, rank) ~= "" then
+		player:set_attribute("ranks:rank-old", player:get_attribute("ranks:rank"))
+		player:set_attribute("ranks:rank", nil)
 	end
 
 	if ranks.get_rank(name) then
@@ -298,6 +303,10 @@ minetest.register_chatcommand("rank", {
 		if #param == 1 and param[1] == "list" then
 			return true, "Available Ranks: "..ranks.list_plaintext()
 		elseif #param == 2 then
+			if minetest.player_exists(param[1]) == false then
+					return false, "Player does not exist"
+			end
+
 			if ranks.get_def(param[2]) then
 				if ranks.set_rank(param[1], param[2]) then
 					if name ~= param[1] then
@@ -329,10 +338,10 @@ minetest.register_chatcommand("getrank", {
 			local rank = ranks.get_rank(param)
 			if rank then
 				return true, "Rank of " .. param .. ": " .. rank:gsub("^%l", string.upper)
-			elseif minetest.get_player_by_name(param) then
+			elseif minetest.player_exists(param) then
 				return false, "Rank of " .. param .. ": No rank"
 			else
-				return false, "Player doesn't exist"
+				return false, "Player does not exist"
 			end
 		else
 			local rank = ranks.get_rank(name) or "No rank"

--- a/init.lua
+++ b/init.lua
@@ -56,9 +56,9 @@ end
 -- [function] Get player rank
 function ranks.get_rank(name)
 	if type(name) ~= "string" then
-		name = name:get_player_name()
+		name = minetest.get_player_by_name(name)
 	end
-	
+
 	local rank = storage:get_string(name)
 	if rank ~= "" and registered[rank] then
 		return rank
@@ -149,7 +149,9 @@ function ranks.update_nametag(name)
 		return
 	end
 
-	if type(name) == "string" then
+	if type(name) ~= "string" then
+		player = name:get_player_name()
+	else
 		player = minetest.get_player_by_name(name)
 	end
 
@@ -195,7 +197,9 @@ end
 
 -- [function] Remove rank from player
 function ranks.remove_rank(name)
-	if type(name) == "string" then
+	if type(name) ~= "string" then
+		player = name:get_player_name()
+	else
 		player = minetest.get_player_by_name(name)
 	end
 
@@ -283,25 +287,21 @@ minetest.register_chatcommand("rank", {
 		if #param == 1 and param[1] == "list" then
 			return true, "Available Ranks: "..ranks.list_plaintext()
 		elseif #param == 2 then
-			if ranks.get_rank(param[1]) then
-				if ranks.get_def(param[2]) then
-					if ranks.set_rank(param[1], param[2]) then
-						if name ~= param[1] then
-							minetest.chat_send_player(param[1], name.." set your rank to "..param[2])
-						end
-
-						return true, "Set "..param[1].."'s rank to "..param[2]
-					else
-						return false, "Unknown error while setting "..param[1].."'s rank to "..param[2]
+			if ranks.get_def(param[2]) then
+				if ranks.set_rank(param[1], param[2]) then
+					if name ~= param[1] then
+						minetest.chat_send_player(param[1], name.." set your rank to "..param[2])
 					end
-				elseif param[2] == "clear" then
-					ranks.remove_rank(param[1])
-					return true, "Removed rank from "..param[1]
+
+					return true, "Set "..param[1].."'s rank to "..param[2]
 				else
-					return false, "Invalid rank (see /rank list)"
+					return false, "Unknown error while setting "..param[1].."'s rank to "..param[2]
 				end
+			elseif param[2] == "clear" then
+				ranks.remove_rank(param[1])
+				return true, "Removed rank from "..param[1]
 			else
-				return false, "Invalid player \""..param[1].."\""
+				return false, "Invalid rank (see /rank list)"
 			end
 		else
 			return false, "Invalid usage (see /help rank)"

--- a/init.lua
+++ b/init.lua
@@ -319,19 +319,17 @@ minetest.register_chatcommand("getrank", {
 	params = "<name> | name of player",
 	func = function(name, param)
 		if param and param ~= "" then
-			if storage:get_string(param) then
-				local rank = storage:get_string(param):gsub("^%l", string.upper)
-				return true, "Rank of "..param..": "..rank
+			local rank = ranks.get_rank(param)
+			if rank then
+				return true, "Rank of " .. param .. ": " .. rank:gsub("^%l", string.upper)
+			elseif minetest.get_player_by_name(param) then
+				return false, "Rank of " .. param .. ": No rank"
 			else
-				return false, "Rank of "..param..": No rank"
+				return false, "Player doesn't exist"
 			end
 		else
-			if storage:get_string(name) then
-				local rank = storage:get_string(name):gsub("^%l", string.upper) or "No rank"
-				return false, "Your rank: "..rank
-			else
-				return false, "Your rank: No rank"
-			end
+			local rank = ranks.get_rank(name) or "No rank"
+			return true, "Your rank: " .. rank:gsub("^%l", string.upper)
 		end
 	end,
 })

--- a/init.lua
+++ b/init.lua
@@ -55,12 +55,13 @@ end
 
 -- [function] Get player rank
 function ranks.get_rank(name)
-	if type(name) == "string" then
-		local rank = storage:get_string(name)
-
-		if rank ~= "" and registered[rank] then
-			return rank
-		end
+	if type(name) ~= "string" then
+		name = name:get_player_name()
+	end
+	
+	local rank = storage:get_string(name)
+	if rank ~= "" and registered[rank] then
+		return rank
 	end
 end
 
@@ -84,7 +85,7 @@ function ranks.update_privs(name, trigger)
 	end
 
 	local rank = ranks.get_rank(name)
-	if ranks.get_rank(name) ~= nil then
+	if rank ~= nil then
 		-- [local function] Warn
 		local function warn(msg)
 			if msg and trigger and minetest.get_player_by_name(trigger) then
@@ -157,7 +158,7 @@ function ranks.update_nametag(name)
 	end
 
 	local rank = ranks.get_rank(name)
-	if ranks.get_rank(name) ~= nil then
+	if rank ~= nil then
 		local def    = ranks.get_def(rank)
 		local colour = get_colour(def.colour)
 		local prefix = def.prefix
@@ -168,9 +169,11 @@ function ranks.update_nametag(name)
 			prefix = ""
 		end
 
-		player:set_nametag_attributes({
-			text = prefix..name,
-		})
+		if player then
+			player:set_nametag_attributes({
+				text = prefix..name,
+			})
+		end
 
 		return true
 	end
@@ -185,13 +188,10 @@ function ranks.set_rank(name, rank)
 	if registered[rank] then
 		storage:set_string(name, rank)
 
-		-- Set attribute
-		if minetest.get_player_by_name(name) then
-			-- Update nametag
-			ranks.update_nametag(player)
-			-- Update privileges
-			ranks.update_privs(player)
-		end
+		-- Update nametag
+		ranks.update_nametag(name)
+		-- Update privileges
+		ranks.update_privs(name)
 
 		return true
 	end
@@ -204,7 +204,7 @@ function ranks.remove_rank(name)
 	end
 
 	local rank = ranks.get_rank(name)
-	if rank.get_rank(name) ~= nil then
+	if rank ~= nil then
 		storage:set_string(name, nil)
 
 		if minetest.get_player_by_name(name) then
@@ -225,7 +225,7 @@ end
 function ranks.chat_send(name, message)
 	if minetest.settings:get("ranks.prefix_chat") ~= "false" then
 		local rank = ranks.get_rank(name)
-		if rank.get_rank(name) ~= nil then
+		if rank ~= nil then
 			local def = ranks.get_def(rank)
 			if def.prefix then
 				local colour = get_colour(def.colour)

--- a/init.lua
+++ b/init.lua
@@ -150,7 +150,7 @@ function ranks.update_nametag(name)
 	end
 
 	if type(name) ~= "string" then
-		player = name:get_player_name()
+		name = name:get_player_name()
 	else
 		player = minetest.get_player_by_name(name)
 	end
@@ -167,6 +167,7 @@ function ranks.update_nametag(name)
 			prefix = ""
 		end
 
+		local player = minetest.get_player_by_name(name)
 		if player then
 			player:set_nametag_attributes({
 				text = prefix..name,
@@ -198,7 +199,7 @@ end
 -- [function] Remove rank from player
 function ranks.remove_rank(name)
 	if type(name) ~= "string" then
-		player = name:get_player_name()
+		name = name:get_player_name()
 	else
 		player = minetest.get_player_by_name(name)
 	end
@@ -207,6 +208,7 @@ function ranks.remove_rank(name)
 	if rank ~= nil then
 		storage:set_string(name, nil)
 
+		local player = minetest.get_player_by_name(name)
 		if player then
 			-- Update nametag
 			player:set_nametag_attributes({

--- a/init.lua
+++ b/init.lua
@@ -180,7 +180,7 @@ end
 -- [function] Set player rank
 function ranks.set_rank(name, rank)
 	if type(name) ~= "string" then
-    	name = name:get_player_name()
+		name = name:get_player_name()
 	end
 
 	if registered[rank] then
@@ -208,6 +208,12 @@ function ranks.remove_rank(name)
 		storage:set_string(name, nil)
 
 		if player then
+
+			-- Remove old rank storage if exists
+			if player:get_attribute("ranks:rank") ~= "" then
+				player:set_attribute("ranks:rank", nil)
+			end
+
 			-- Update nametag
 			player:set_nametag_attributes({
 				text = name,
@@ -255,6 +261,11 @@ minetest.register_privilege("rank", {
 -- Assign/update rank on join player
 minetest.register_on_joinplayer(function(player)
 	local name = player:get_player_name()
+
+	-- If database item exists and new storage item does not, use database item
+	if player:get_attribute("ranks:rank") ~= "" and storage:get_string(name, rank) == "" then
+		storage:set_string(name, player:get_attribute("ranks:rank"))
+	end
 
 	if ranks.get_rank(name) then
 		-- Update nametag

--- a/init.lua
+++ b/init.lua
@@ -76,12 +76,8 @@ end
 
 -- [function] Update player privileges
 function ranks.update_privs(name, trigger)
-	if type(name) == "string" then
-		player = minetest.get_player_by_name(name)
-	end
-
-	if not player then
-		return
+	if type(name) ~= "string" then
+    	name = name:get_player_name()
 	end
 
 	local rank = ranks.get_rank(name)
@@ -179,10 +175,10 @@ function ranks.update_nametag(name)
 	end
 end
 
--- [function] Set player rank TODO
+-- [function] Set player rank
 function ranks.set_rank(name, rank)
-	if type(name) == "string" then
-		player = minetest.get_player_by_name(name)
+	if type(name) ~= "string" then
+    	name = name:get_player_name()
 	end
 
 	if registered[rank] then
@@ -200,14 +196,14 @@ end
 -- [function] Remove rank from player
 function ranks.remove_rank(name)
 	if type(name) == "string" then
-		name = minetest.get_player_by_name(name)
+		player = minetest.get_player_by_name(name)
 	end
 
 	local rank = ranks.get_rank(name)
 	if rank ~= nil then
 		storage:set_string(name, nil)
 
-		if minetest.get_player_by_name(name) then
+		if player then
 			-- Update nametag
 			player:set_nametag_attributes({
 				text = name,
@@ -287,7 +283,7 @@ minetest.register_chatcommand("rank", {
 		if #param == 1 and param[1] == "list" then
 			return true, "Available Ranks: "..ranks.list_plaintext()
 		elseif #param == 2 then
-			if minetest.get_player_by_name(param[1]) or ranks.get_rank(param[1]) then
+			if ranks.get_rank(param[1]) then
 				if ranks.get_def(param[2]) then
 					if ranks.set_rank(param[1], param[2]) then
 						if name ~= param[1] then


### PR DESCRIPTION
Closes: #2 

Stores a file in each world folder (`ranks.txt`) which contains players names and ranks. It works where once the player has joined and a rank has been assigned, the rank can always be changed whether the player is online or offline. But if the rank of the player is cleared, they will have to be 're-ranked' while online.

Of course, currently existing ranks for players will not exist in the file as I'm not sure how I'd get them without all of the players being online; meaning that from now on, the ranks will be stored in a file.